### PR TITLE
Stringify header keys for request

### DIFF
--- a/lib/nugget/service.rb
+++ b/lib/nugget/service.rb
@@ -110,6 +110,12 @@ module Nugget
         options.delete(:url)
       end
 
+      if options[:headers]
+        options[:headers] = options[:headers].each_with_object({}) do |(key, value), result|
+          result[key.to_s] = value
+        end
+      end
+
       {
         :url => url,
         :type => definition[:type],


### PR DESCRIPTION
`Mixlib::Config` reads in our config file with entirely Symbol keys, causing problems when you wish to override headers given to you by Typhoeus with String keys. This change converts the Symbol header keys into String keys.

/cc @joewilliams @keithduncan @github/pages